### PR TITLE
chore: make default base-branch main

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Github action that provides support for bumping multiples packages of a monorepo
 
 | Name           | Description                                                   | Required | Default |
 | -------------- | ------------------------------------------------------------- | -------- | ------- |
-| base-branch    | Branch in which release will be merged                        | true     | master  |
+| base-branch    | Branch in which release will be merged                        | true     | main  |
 | head-branch    | Branch to be released                                         | true     | develop |
 | github-token   | Github token with access to commit in head-branch             | true     |         |
 | initial-branch | Initial version used if base-branch doesn't have package.json | false    | 0.0.0   |

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   base-branch:
     description: 'branch in which release will be merged'
     required: true
-    default: 'master'
+    default: 'main'
 
   head-branch:
     description: 'branch to be released'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "release-monorepo",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-monorepo-action",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "description": "Github action that provides support for bumping multiples packages of a monorepo.",
   "main": "index.js",
   "author": "Lemon Energy",


### PR DESCRIPTION
BREAKING CHANGE: if a repo uses master as its base-branch it will break CI