### PR TITLE
Feat/workspaces/add workspace flag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//npm.pkg.github.com/:_authToken=${PERSONAL_GITHUB_TOKEN}
+@lemonenergy:registry=https://npm.pkg.github.com/lemonenergy

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Github action that provides support for bumping multiples packages of a monorepo
 
 ## Inputs
 
-| Name           | Description                                                   | Required | Default |
-| -------------- | ------------------------------------------------------------- | -------- | ------- |
-| base-branch    | Branch in which release will be merged                        | true     | main  |
-| head-branch    | Branch to be released                                         | true     | develop |
-| github-token   | Github token with access to commit in head-branch             | true     |         |
-| initial-branch | Initial version used if base-branch doesn't have package.json | false    | 0.0.0   |
+| Name           | Description                                                                      | Required | Default |
+| -------------- | -------------------------------------------------------------------------------- | -------- | ------- |
+| base-branch    | Branch in which release will be merged                                           | true     | main    |
+| head-branch    | Branch to be released                                                            | true     | develop |
+| github-token   | Github token with access to commit in head-branch                                | true     |         |
+| initial-branch | Initial version used if base-branch doesn't have package.json                    | false    | 0.0.0   |
+| workspaces     | add --sync-workspace-lock flag which is recommended when working with workspaces | false    | false   |
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,12 @@ inputs:
     required: true
 
   initial-version:
-    description: "initial version used if base-branch doesn't have package.json"
+    description: 'initial version used if base-branch doesn't have package.json'
     default: '0.0.0'
+
+  workspaces:
+    description: 'add --sync-workspace-lock flag which is recommended when working with workspaces'
+    default: false
 
 runs:
   using: 'node12'

--- a/index.js
+++ b/index.js
@@ -89,9 +89,13 @@ const forceBaseVersions = async baseVersions => {
   return exec(`git commit -a --amend --no-edit`)
 }
 
-const bump = async () => {
+const bump = async (workspaces) => {
+  let execCommand = `npx lerna version --conventional-commits --create-release github --no-push --yes --force-git-tag`
+
+  if (workspaces) execCommand += " --sync-workspace-lock"
+
   await exec(
-    `npx lerna version --conventional-commits --create-release github --no-push --yes --force-git-tag`,
+   execCommand,
   )
 }
 
@@ -111,6 +115,7 @@ const run = async () => {
   const base = core.getInput('base-branch')
   const head = core.getInput('head-branch')
   const initialVersion = core.getInput('initial-version')
+  const workspaces = core.getInput('workspaces')
   try {
     const baseVersions = await getBaseVersions(base, initialVersion)
     console.log(`fetched base versions`, baseVersions)
@@ -118,7 +123,7 @@ const run = async () => {
     await configGit(head)
     await forceBaseVersions(baseVersions)
     console.log(`forced base versions in packages`)
-    await bump()
+    await bump(workspaces)
     console.log(`bumped packages!`)
     await pushBumpedVersionAndTag(head)
     console.log(`pushed release!`)

--- a/index.js
+++ b/index.js
@@ -92,8 +92,6 @@ const forceBaseVersions = async baseVersions => {
 const bump = async (workspaces) => {
   let execCommand = `npx lerna version --conventional-commits --create-release github --no-push --yes --force-git-tag`
 
-  // Actions metadata inputs are string values
-  // https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddefault
   if (workspaces && workspaces == 'true') execCommand += " --sync-workspace-lock"
 
   await exec(

--- a/index.js
+++ b/index.js
@@ -92,7 +92,9 @@ const forceBaseVersions = async baseVersions => {
 const bump = async (workspaces) => {
   let execCommand = `npx lerna version --conventional-commits --create-release github --no-push --yes --force-git-tag`
 
-  if (workspaces) execCommand += " --sync-workspace-lock"
+  // Actions metadata inputs are string values
+  // https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputsinput_iddefault
+  if (workspaces && workspaces == 'true') execCommand += " --sync-workspace-lock"
 
   await exec(
    execCommand,


### PR DESCRIPTION
Pequena atualização que adiciona a possibilidade de incluir a [flag](https://github.com/lerna-lite/lerna-lite/tree/main/packages/version#--sync-workspace-lock) `--sync-workspace-lock` no comando de version. 